### PR TITLE
check positions before update!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FinancialPortfolios"
 uuid = "7b36c455-f227-419f-b582-14f635f70924"
 authors = ["Tyler Beason <tbeas12@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 

--- a/src/FinancialPortfolios.jl
+++ b/src/FinancialPortfolios.jl
@@ -110,6 +110,73 @@ function update!(fp::FinancialPortfolio,ret)
 end
 
 
+
+
+
+
+
+
+"""
+    safeportfolioreturn(fp::FinancialPortfolio,ret)
+
+Compute the weighted portfolio return. If the portfolio weights have names or identifiers, the returns should as well.
+If `ret` does not contain an entry for one of the existing portfolio positions, this function assumes the position was closed.
+
+
+_**Example**_
+```
+w = [0.5, 0.25, 0.25]
+r = [0.1, 0.1, -0.1]
+FP = FinancialPortfolio(w)
+safeportfolioreturn(FP,r)
+```
+"""
+function safeportfolioreturn(fp::FinancialPortfolio,ret)
+    portreturn = 0.0
+    for k in eachindex(fp.positions)
+        if haskey(keys(ret),k)
+            portreturn += fp.positions[k] * ret[k]
+        end
+    end
+    return portreturn
+end
+
+
+
+
+
+
+
+"""
+    safeupdate!(fp::FinancialPortfolio,ret)
+
+Updates the weights of the portfolio in place. Returns the period portfolio return.
+
+If `ret` does not contain an entry for one of the existing portfolio positions, this function assumes the position was closed.
+
+_**Example**_
+```
+w = [0.5, 0.25, 0.25]
+r = [0.1, 0.1, -0.1]
+FP = FinancialPortfolio(w)
+update!(FP,r)
+FP
+```
+"""
+function safeupdate!(fp::FinancialPortfolio,ret)
+    portreturn = safeportfolioreturn(fp,ret)
+    
+    for k in eachindex(fp.positions)
+        if haskey(keys(ret),k)
+            fp.positions[k] = fp.positions[k] * (1+ret[k])
+        else
+            fp.positions[k] = 0.0
+        end
+    end
+    normalize!(fp)
+    return portreturn
+end
+
 ##################### UNEXPORTED AND/OR EXTENDED BASE METHODS
 """
     FinancialPortfolios.normalize!(fp::FinancialPortfolio)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,7 @@ ret_dict_int = Dict(Iterators.zip(1:3,r))
     @test portfolioreturn(FP2,r) ≈ ewret
     @test sort(keys(FP)) == [1,2,3]
     @test isempty(FP) == false
+    @test_throws AssertionError checkupdate!(FP,r)
 end
 
 @testset "Dict-String" begin
@@ -51,6 +52,12 @@ end
     FP2 = similar(FP)
     @test portfolioreturn(FP2,ret) ≈ ewret
     @test sort(keys(FP)) == nm
+    ret_dict_minus = copy(ret_dict)
+    delete!(ret_dict_minus,"a")
+    @test checkupdate!(FinancialPortfolio(plain_dict),ret_dict_minus) ≈ 0
+    checkupdate!(FP,ret_dict_minus)
+    @test length(FP) == length(w)-1
+    @test keys(FP.positions) == keys(ret_dict_minus)
 end
 
 @testset "Dict-Symbol" begin


### PR DESCRIPTION
the `checkupdate!` function will see if a position exists before trying to update it. if the position does not exist, it is deleted from the portfolio. the portfolio is renormalized before calling a new `update!`

this PR also includes tests and a small bugfix related to copying portfolios